### PR TITLE
feat: Add iOS 17+ location simulation support via pymobiledevice3

### DIFF
--- a/LocationSimulator.xcodeproj/project.pbxproj
+++ b/LocationSimulator.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		636FD9EA2989BBAB004FBFFF /* CLLocationSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636FD9E92989BBAB004FBFFF /* CLLocationSpeed.swift */; };
 		637169D627FD880200386021 /* LocationSpoofer+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637169D527FD880200386021 /* LocationSpoofer+Extension.swift */; };
 		637169D827FD8D0A00386021 /* Device+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637169D727FD8D0A00386021 /* Device+Extension.swift */; };
+		AA0001012A0000010000AA01 /* PMD3Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001002A0000010000AA01 /* PMD3Helper.swift */; };
+		AA0001032A0000010000AA03 /* PMD3DeviceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001022A0000010000AA03 /* PMD3DeviceWrapper.swift */; };
 		637169DA27FF1C2400386021 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637169D927FF1C2400386021 /* main.swift */; };
 		6372061D25911CED00293EA8 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6372061C25911CED00293EA8 /* MapView.swift */; };
 		63720636259147AB00293EA8 /* DownloadProgressAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63720635259147AB00293EA8 /* DownloadProgressAlert.swift */; };
@@ -287,6 +289,8 @@
 		636FD9E92989BBAB004FBFFF /* CLLocationSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocationSpeed.swift; sourceTree = "<group>"; };
 		637169D527FD880200386021 /* LocationSpoofer+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocationSpoofer+Extension.swift"; sourceTree = "<group>"; };
 		637169D727FD8D0A00386021 /* Device+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Device+Extension.swift"; sourceTree = "<group>"; };
+		AA0001002A0000010000AA01 /* PMD3Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PMD3Helper.swift; sourceTree = "<group>"; };
+		AA0001022A0000010000AA03 /* PMD3DeviceWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PMD3DeviceWrapper.swift; sourceTree = "<group>"; };
 		637169D927FF1C2400386021 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		6372061C25911CED00293EA8 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		63720635259147AB00293EA8 /* DownloadProgressAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadProgressAlert.swift; sourceTree = "<group>"; };
@@ -628,6 +632,8 @@
 			children = (
 				637169D727FD8D0A00386021 /* Device+Extension.swift */,
 				637169D527FD880200386021 /* LocationSpoofer+Extension.swift */,
+				AA0001002A0000010000AA01 /* PMD3Helper.swift */,
+				AA0001022A0000010000AA03 /* PMD3DeviceWrapper.swift */,
 			);
 			path = LocationSpoofer;
 			sourceTree = "<group>";
@@ -1205,7 +1211,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1020;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 2620;
 				ORGANIZATIONNAME = "David Klopp";
 				TargetAttributes = {
 					13BA351520A433EE00A0431C = {
@@ -1470,6 +1476,8 @@
 				63C6F8B129BC698A005CED5D /* ASStorage.swift in Sources */,
 				63767567258EA9AA000DCEF3 /* NSImageView+Extension.swift in Sources */,
 				637169D827FD8D0A00386021 /* Device+Extension.swift in Sources */,
+				AA0001012A0000010000AA01 /* PMD3Helper.swift in Sources */,
+				AA0001032A0000010000AA03 /* PMD3DeviceWrapper.swift in Sources */,
 				63D5DF3827D8F12E00F2DCD3 /* AddDeveloperDiskImageView.swift in Sources */,
 				631EBFE3259409190066D5BB /* Notification+Extension.swift in Sources */,
 				63C6F8A629BBFD1C005CED5D /* Application+CoordinateSuite.swift in Sources */,
@@ -1539,6 +1547,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1573,8 +1583,10 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = YJ8XYES89R;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1595,6 +1607,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1605,6 +1618,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1639,8 +1654,10 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = YJ8XYES89R;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1654,6 +1671,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -1671,8 +1689,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = YJ8XYES89R;
+				DEVELOPMENT_TEAM = 7C252RKZ47;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_RESOURCE_ACCESS_LOCATION = YES;
+				ENABLE_RESOURCE_ACCESS_USB = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				FRAMEWORK_SEARCH_PATHS = "";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "LocationSimulator/Supporting Files/Info.plist";
@@ -1682,14 +1706,20 @@
 				);
 				LIBRARY_SEARCH_PATHS = "";
 				MACH_O_TYPE = mh_execute;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = de.davidklopp.locationsimulator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "LocationSimulator-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -1704,8 +1734,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = YJ8XYES89R;
+				DEVELOPMENT_TEAM = 7C252RKZ47;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_RESOURCE_ACCESS_LOCATION = YES;
+				ENABLE_RESOURCE_ACCESS_USB = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				FRAMEWORK_SEARCH_PATHS = "";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "LocationSimulator/Supporting Files/Info.plist";
@@ -1715,13 +1751,19 @@
 				);
 				LIBRARY_SEARCH_PATHS = "";
 				MACH_O_TYPE = mh_execute;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = de.davidklopp.locationsimulator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "LocationSimulator-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -1729,6 +1771,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1763,8 +1806,10 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = YJ8XYES89R;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1778,6 +1823,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -1795,8 +1841,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = YJ8XYES89R;
+				DEVELOPMENT_TEAM = 7C252RKZ47;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_RESOURCE_ACCESS_LOCATION = YES;
+				ENABLE_RESOURCE_ACCESS_USB = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				FRAMEWORK_SEARCH_PATHS = "";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "LocationSimulator/Supporting Files/Info.plist";
@@ -1806,14 +1858,20 @@
 				);
 				LIBRARY_SEARCH_PATHS = "";
 				MACH_O_TYPE = mh_execute;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = de.davidklopp.locationsimulator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "LocationSimulator-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Homebrew;
 		};
@@ -1821,18 +1879,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = YJ8XYES89R;
+				DEVELOPMENT_TEAM = 7C252RKZ47;
 				GENERATE_INFOPLIST_FILE = NO;
 				GENERATE_PKGINFO_FILE = YES;
 				INFOPLIST_FILE = Help/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 David Klopp. All rights reserved.";
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1848,18 +1907,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = YJ8XYES89R;
+				DEVELOPMENT_TEAM = 7C252RKZ47;
 				GENERATE_INFOPLIST_FILE = NO;
 				GENERATE_PKGINFO_FILE = YES;
 				INFOPLIST_FILE = Help/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 David Klopp. All rights reserved.";
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = de.davidklopp.locationsimulatorhelp;
@@ -1874,18 +1934,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = YJ8XYES89R;
+				DEVELOPMENT_TEAM = 7C252RKZ47;
 				GENERATE_INFOPLIST_FILE = NO;
 				GENERATE_PKGINFO_FILE = YES;
 				INFOPLIST_FILE = Help/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 David Klopp. All rights reserved.";
 				INFOPLIST_KEY_NSPrincipalClass = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = de.davidklopp.locationsimulatorhelp;

--- a/LocationSimulator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LocationSimulator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash" : "6d6e6843a9780196fb4b2c1f13fd83643493df9a7fa74d0b864c20342a46f142",
+  "pins" : [
+    {
+      "identity" : "clogger",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Schlaubischlump/CLogger",
+      "state" : {
+        "revision" : "3e86131e5670210f68bcf384067c49df74daa75a",
+        "version" : "0.0.1"
+      }
+    },
+    {
+      "identity" : "downloader",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Schlaubischlump/Downloader.git",
+      "state" : {
+        "revision" : "81c0732d2524322d0183e06c6ce96e70d9cefa2f",
+        "version" : "0.0.3"
+      }
+    },
+    {
+      "identity" : "gpxparser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Schlaubischlump/GPXParser",
+      "state" : {
+        "revision" : "f892628aa7a72608bc89ea1fea1d6562447bfbc2",
+        "version" : "0.0.2"
+      }
+    },
+    {
+      "identity" : "locationspoofer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Schlaubischlump/LocationSpoofer.git",
+      "state" : {
+        "revision" : "9b68601e59bfbfc92a562f91cbf34277f1107bbb",
+        "version" : "0.0.4"
+      }
+    },
+    {
+      "identity" : "openssl-apple",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/passepartoutvpn/openssl-apple.git",
+      "state" : {
+        "revision" : "757c074af45e4f2514fe63f649ccdde966183e90",
+        "version" : "1.1.11700"
+      }
+    },
+    {
+      "identity" : "suggestionpopup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Schlaubischlump/SuggestionPopup.git",
+      "state" : {
+        "revision" : "0f8838a7747a0e2e06c936dd677bd871eece94d7",
+        "version" : "0.0.6"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/LocationSimulator.xcodeproj/xcshareddata/xcschemes/LocationSimulator.xcscheme
+++ b/LocationSimulator.xcodeproj/xcshareddata/xcschemes/LocationSimulator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "2620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LocationSimulator/AppDelegate.swift
+++ b/LocationSimulator/AppDelegate.swift
@@ -24,25 +24,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
-        // We do not want to present the donation and intro window at the same time.
-        if !self.openOnboardingScreenOnFirstLaunch() {
-            self.openInfoViewOnVersionUpdate()
-        }
-    }
-
-    /// Open the InfoViewController when the version number changed. This way we can inform the user about critical
-    /// changes and remind him/her to donate ;)
-    @discardableResult
-    private func openInfoViewOnVersionUpdate() -> Bool {
-        let defaults = UserDefaults.standard
-        if defaults.lastAppVersion != kAppVersion {
-            // FIXME: Segue would be nicer, but does not work
-            AppMenubarItem.preferences.triggerAction()
-            // Update the last app version
-            defaults.lastAppVersion = kAppVersion
-            return true
-        }
-        return false
+        self.openOnboardingScreenOnFirstLaunch()
     }
 
     @discardableResult

--- a/LocationSimulator/Extensions/LocationSpoofer/Device+Extension.swift
+++ b/LocationSimulator/Extensions/LocationSpoofer/Device+Extension.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import LocationSpoofer
+import CLogger
 
 extension Device {
     /// Get the current iOS Version in major.minor format, without any additional revision number.
@@ -18,13 +19,22 @@ extension Device {
         return "\(majorVersion).\(minorVersion)"
     }
 
+    /// Whether this device is iOS 17+ and requires pymobiledevice3 instead of DeveloperDiskImage.
+    public var requiresPMD3: Bool {
+        return PMD3Helper.deviceRequiresPMD3(self.majorVersion)
+    }
+
     public func enabledDeveloperModeToggleInSettings() {
         // Only real iOS Devices require developer mode
-        guard let device = self as? IOSDevice else { return }
-        device.enabledDeveloperModeToggleInSettings()
+        if let device = self as? IOSDevice {
+            device.enabledDeveloperModeToggleInSettings()
+        } else if let wrapper = self as? PMD3DeviceWrapper {
+            wrapper.wrappedDevice.enabledDeveloperModeToggleInSettings()
+        }
     }
 
     /// Pair a new device by uploading the developer disk image if required.
+    /// For iOS 17+ devices with pymobiledevice3, this starts the tunneld service instead.
     /// - Throws:
     ///    * `DeviceError.devDiskImageNotFound`: Required DeveloperDiskImage support file not found
     ///    * `DeviceError.devDiskImageMount`: Error mounting the DeveloperDiskImage file
@@ -32,8 +42,30 @@ extension Device {
     ///    * `DeviceError.permisson`: Permission error while accessing the App Support folder
     ///    * `DeviceError.productInfo`: Could not read the devices product version or name
     public func pair() throws {
+        // PMD3DeviceWrapper handles iOS 17+ — start tunneld and skip DDI mounting
+        if let wrapper = self as? PMD3DeviceWrapper, wrapper.usesPMD3 {
+            logInfo("Device+Extension: iOS 17+ device — starting tunneld for pymobiledevice3")
+            if !PMD3Helper.shared.ensureTunneld() {
+                throw DeviceError.devDiskImageNotFound(
+                    "Failed to start tunneld. Please ensure pymobiledevice3 is installed and try running:\n" +
+                    "sudo pymobiledevice3 remote tunneld -d\n\n" +
+                    "Then restart LocationSimulator."
+                )
+            }
+            logInfo("Device+Extension: tunneld ready — device can now simulate location")
+            return
+        }
+
         // Only real iOS Devices require a pairing if the DeveloperDiskImage is not already mounted
         guard let device = self as? IOSDevice, !device.developerDiskImageIsMounted else { return }
+
+        // For iOS 17+ without pymobiledevice3, warn the user
+        if PMD3Helper.deviceRequiresPMD3(device.majorVersion) && !PMD3Helper.shared.isAvailable {
+            logError("Device+Extension: iOS 17+ detected but pymobiledevice3 is not installed!")
+            throw DeviceError.devDiskImageNotFound(
+                "iOS 17+ requires pymobiledevice3. Install it with: python3 -m pip install pymobiledevice3"
+            )
+        }
 
         // Make sure the C-backend can read the files
         let fileManager = FileManager.default

--- a/LocationSimulator/Extensions/LocationSpoofer/PMD3DeviceWrapper.swift
+++ b/LocationSimulator/Extensions/LocationSpoofer/PMD3DeviceWrapper.swift
@@ -1,0 +1,90 @@
+//
+//  PMD3DeviceWrapper.swift
+//  LocationSimulator
+//
+//  A wrapper around IOSDevice that uses pymobiledevice3 for location simulation
+//  on iOS 17+ devices, while keeping the original device discovery mechanism.
+//
+
+import Foundation
+import CoreLocation
+import LocationSpoofer
+import CLogger
+
+/// Wraps an existing IOSDevice to use pymobiledevice3 for location operations on iOS 17+.
+/// For iOS 16 and below, delegates to the original device implementation.
+public class PMD3DeviceWrapper: Device {
+    /// The wrapped original iOS device
+    public let wrappedDevice: IOSDevice
+
+    /// Whether this device uses pymobiledevice3 for location simulation
+    public let usesPMD3: Bool
+
+    // MARK: - Device Protocol Conformance
+
+    public var udid: String { return wrappedDevice.udid }
+    public var name: String { return wrappedDevice.name }
+    public var version: String? { return wrappedDevice.version }
+    public var productName: String? { return wrappedDevice.productName }
+    public var connectionType: ConnectionType { return wrappedDevice.connectionType }
+    public var majorVersion: Int? { return wrappedDevice.majorVersion }
+    public var minorVersion: Int { return wrappedDevice.minorVersion }
+
+    // Static device methods delegate to IOSDevice
+    public static var availableDevices: [Device] {
+        return IOSDevice.availableDevices
+    }
+
+    public static var isGeneratingDeviceNotifications: Bool {
+        return IOSDevice.isGeneratingDeviceNotifications
+    }
+
+    @discardableResult
+    public static func startGeneratingDeviceNotifications() -> Bool {
+        return IOSDevice.startGeneratingDeviceNotifications()
+    }
+
+    @discardableResult
+    public static func stopGeneratingDeviceNotifications() -> Bool {
+        return IOSDevice.stopGeneratingDeviceNotifications()
+    }
+
+    // MARK: - Init
+
+    public init(wrapping device: IOSDevice) {
+        self.wrappedDevice = device
+        self.usesPMD3 = PMD3Helper.deviceRequiresPMD3(device.majorVersion) && PMD3Helper.shared.isAvailable
+        if self.usesPMD3 {
+            logInfo("PMD3DeviceWrapper: iOS \(device.version ?? "?") detected — using pymobiledevice3 backend")
+        }
+    }
+
+    // MARK: - Location Simulation
+
+    /// Set the device location. Uses pymobiledevice3 for iOS 17+, original method for older versions.
+    @discardableResult
+    public func simulateLocation(_ location: CLLocationCoordinate2D) -> Bool {
+        if usesPMD3 {
+            return PMD3Helper.shared.simulateLocation(location, udid: self.udid)
+        } else {
+            return wrappedDevice.simulateLocation(location)
+        }
+    }
+
+    /// Disable location simulation. Uses pymobiledevice3 for iOS 17+, original method for older versions.
+    @discardableResult
+    public func disableSimulation() -> Bool {
+        if usesPMD3 {
+            return PMD3Helper.shared.disableSimulation(udid: self.udid)
+        } else {
+            return wrappedDevice.disableSimulation()
+        }
+    }
+
+    // MARK: - Description
+
+    public var description: String {
+        let backend = usesPMD3 ? "pymobiledevice3" : "libimobiledevice"
+        return "PMD3DeviceWrapper(\(wrappedDevice.name), iOS \(version ?? "?"), backend: \(backend))"
+    }
+}

--- a/LocationSimulator/Extensions/LocationSpoofer/PMD3Helper.swift
+++ b/LocationSimulator/Extensions/LocationSpoofer/PMD3Helper.swift
@@ -1,0 +1,293 @@
+//
+//  PMD3Helper.swift
+//  LocationSimulator
+//
+//  Helper class that wraps pymobiledevice3 CLI for iOS 17+ location simulation.
+//  pymobiledevice3 supports the new RemoteXPC/tunneld protocol that Apple requires
+//  for developer services on iOS 17 and later.
+//
+
+import Foundation
+import CoreLocation
+import CLogger
+
+/// Helper class to interact with pymobiledevice3 for iOS 17+ devices.
+///
+/// Architecture:
+/// - iOS 17+ requires a RemoteXPC tunnel for developer services
+/// - `tunneld` must run as root (sudo) to create the TUN network interface
+/// - We use `osascript` to request admin privileges for tunneld startup
+/// - Location simulation uses the DVT instruments protocol (`developer dvt simulate-location`)
+///   which connects through the tunnel and stays alive as a persistent process
+/// - When the location changes, the old process is killed and a new one spawned
+/// - To clear the location, the process is simply killed
+class PMD3Helper {
+
+    /// Shared singleton instance
+    static let shared = PMD3Helper()
+
+    /// Path to the pymobiledevice3 CLI binary
+    private let pmd3Path: String
+
+    /// Whether pymobiledevice3 is available on this system
+    private(set) var isAvailable: Bool = false
+
+    /// Whether tunneld has been started/verified this session
+    private var tunneldReady: Bool = false
+
+    /// The currently running DVT simulate-location process (must stay alive to maintain simulation)
+    private var activeSimulationProcess: Process?
+
+    /// Serial queue for managing the simulation process lifecycle
+    private let processQueue = DispatchQueue(label: "com.locationsimulator.pmd3helper")
+
+    /// The minimum iOS major version that requires pymobiledevice3 (17+)
+    static let minimumRequiredVersion: Int = 17
+
+    private init() {
+        self.pmd3Path = PMD3Helper.findPMD3Path()
+        self.isAvailable = !self.pmd3Path.isEmpty && FileManager.default.fileExists(atPath: self.pmd3Path)
+        if self.isAvailable {
+            logInfo("PMD3Helper: Found pymobiledevice3 at \(self.pmd3Path)")
+        } else {
+            logError("PMD3Helper: pymobiledevice3 not found")
+        }
+    }
+
+    /// Check if a device requires pymobiledevice3 (iOS 17+)
+    static func deviceRequiresPMD3(_ majorVersion: Int?) -> Bool {
+        guard let major = majorVersion else { return false }
+        return major >= minimumRequiredVersion
+    }
+
+    // MARK: - Binary Discovery
+
+    /// Find the pymobiledevice3 CLI binary
+    private static func findPMD3Path() -> String {
+        let candidates = [
+            "/Library/Frameworks/Python.framework/Versions/3.12/bin/pymobiledevice3",
+            "/Library/Frameworks/Python.framework/Versions/3.13/bin/pymobiledevice3",
+            "/opt/homebrew/bin/pymobiledevice3",
+            "/usr/local/bin/pymobiledevice3"
+        ]
+
+        for path in candidates {
+            if FileManager.default.fileExists(atPath: path) {
+                return path
+            }
+        }
+
+        // Fallback: try to find via which
+        let task = Process()
+        task.launchPath = "/bin/zsh"
+        task.arguments = ["-l", "-c", "which pymobiledevice3"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !path.isEmpty, FileManager.default.fileExists(atPath: path) {
+                return path
+            }
+        } catch {
+            logError("PMD3Helper: Failed to find pymobiledevice3: \(error)")
+        }
+
+        return ""
+    }
+
+    // MARK: - Tunnel Management
+
+    /// Ensure tunneld is running. If not, start it with sudo via osascript.
+    /// This will prompt the user for their admin password if tunneld isn't already running.
+    /// - Returns: true if tunneld is running (or was started successfully)
+    func ensureTunneld() -> Bool {
+        if tunneldReady && isTunneldRunning() {
+            return true
+        }
+
+        if isTunneldRunning() {
+            logInfo("PMD3Helper: tunneld is already running")
+            tunneldReady = true
+            return true
+        }
+
+        logInfo("PMD3Helper: Starting tunneld with admin privileges...")
+
+        // Use osascript to run tunneld with sudo — this prompts the user for their password
+        let script = """
+        do shell script "\(pmd3Path) remote tunneld -d" with administrator privileges
+        """
+
+        let task = Process()
+        task.launchPath = "/usr/bin/osascript"
+        task.arguments = ["-e", script]
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        task.standardOutput = stdoutPipe
+        task.standardError = stderrPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus != 0 {
+                let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                let stderr = String(data: stderrData, encoding: .utf8) ?? "unknown"
+                logError("PMD3Helper: Failed to start tunneld: \(stderr)")
+                return false
+            }
+        } catch {
+            logError("PMD3Helper: Failed to launch tunneld: \(error)")
+            return false
+        }
+
+        // Wait for tunneld to become ready (up to 15 seconds)
+        logInfo("PMD3Helper: Waiting for tunneld to become ready...")
+        for i in 0..<30 {
+            Thread.sleep(forTimeInterval: 0.5)
+            if isTunneldRunning() {
+                logInfo("PMD3Helper: tunneld is ready (waited \(Double(i + 1) * 0.5)s)")
+                tunneldReady = true
+                return true
+            }
+        }
+
+        logError("PMD3Helper: tunneld did not start within 15 seconds")
+        return false
+    }
+
+    /// Check if tunneld is already running by checking the process list
+    func isTunneldRunning() -> Bool {
+        let task = Process()
+        task.launchPath = "/bin/zsh"
+        task.arguments = ["-c", "pgrep -f 'pymobiledevice3.*tunneld' > /dev/null 2>&1"]
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+            return task.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Location Simulation (DVT Instruments Protocol)
+
+    /// Set a simulated location on the device using pymobiledevice3's DVT instruments protocol.
+    ///
+    /// This launches `pymobiledevice3 developer dvt simulate-location set` as a persistent process.
+    /// The DVT version keeps a connection open to the device — location simulation stays active
+    /// only while the process is alive. When a new location is set, the old process is killed first.
+    ///
+    /// - Parameters:
+    ///   - location: The coordinate to simulate
+    ///   - udid: The device UDID
+    /// - Returns: true on success, false on failure
+    func simulateLocation(_ location: CLLocationCoordinate2D, udid: String) -> Bool {
+        guard isAvailable else {
+            logError("PMD3Helper: pymobiledevice3 is not available")
+            return false
+        }
+
+        guard tunneldReady || ensureTunneld() else {
+            logError("PMD3Helper: Cannot simulate location — tunneld is not running")
+            return false
+        }
+
+        // Kill existing simulation process (if any) before starting a new one
+        killActiveSimulation()
+
+        logInfo("PMD3Helper: Setting location to \(location.latitude), \(location.longitude) for device \(udid)")
+
+        let task = Process()
+        task.launchPath = pmd3Path
+        task.arguments = [
+            "developer", "dvt", "simulate-location", "set",
+            "--tunnel", udid,
+            "--",   // separator so negative coordinates aren't parsed as flags
+            String(location.latitude),
+            String(location.longitude)
+        ]
+
+        let stderrPipe = Pipe()
+        task.standardOutput = Pipe()  // suppress stdout
+        task.standardError = stderrPipe
+
+        // Set up PATH
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/Library/Frameworks/Python.framework/Versions/3.12/bin"
+        ]
+        let currentPath = env["PATH"] ?? "/usr/bin:/bin"
+        env["PATH"] = (extraPaths + [currentPath]).joined(separator: ":")
+        task.environment = env
+
+        do {
+            try task.run()
+        } catch {
+            logError("PMD3Helper: Failed to launch DVT simulate-location: \(error)")
+            return false
+        }
+
+        // Wait briefly for the process to connect and start simulating
+        // The DVT command prints "Press Ctrl+C..." once it's ready
+        Thread.sleep(forTimeInterval: 2.0)
+
+        if !task.isRunning {
+            // Process exited early — read stderr for error details
+            let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            let stderr = String(data: stderrData, encoding: .utf8) ?? "unknown error"
+            logError("PMD3Helper: DVT simulate-location exited early (code \(task.terminationStatus)): \(stderr)")
+            return false
+        }
+
+        logInfo("PMD3Helper: Location simulation active (PID \(task.processIdentifier))")
+
+        processQueue.sync {
+            self.activeSimulationProcess = task
+        }
+
+        return true
+    }
+
+    /// Clear the simulated location by killing the active DVT simulation process.
+    /// - Parameter udid: The device UDID (for logging)
+    /// - Returns: true on success, false on failure
+    func disableSimulation(udid: String) -> Bool {
+        logInfo("PMD3Helper: Clearing simulated location for device \(udid)")
+        killActiveSimulation()
+        return true
+    }
+
+    /// Kill the active simulation process if one is running.
+    private func killActiveSimulation() {
+        processQueue.sync {
+            guard let process = self.activeSimulationProcess else { return }
+            if process.isRunning {
+                logInfo("PMD3Helper: Killing active simulation process (PID \(process.processIdentifier))")
+                process.terminate()
+                // Give it a moment to clean up, then force kill if needed
+                DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) {
+                    if process.isRunning {
+                        process.interrupt()
+                    }
+                }
+            }
+            self.activeSimulationProcess = nil
+        }
+    }
+
+    deinit {
+        killActiveSimulation()
+    }
+}

--- a/LocationSimulator/Storyboard/Main.storyboard
+++ b/LocationSimulator/Storyboard/Main.storyboard
@@ -2448,7 +2448,6 @@
             <objects>
                 <tabViewController selectedTabViewItemIndex="0" tabStyle="toolbar" canPropagateSelectedChildViewControllerTitle="NO" id="rSB-OX-bfh" customClass="PreferencesTabViewController" customModule="LocationSimulator" customModuleProvider="target" sceneMemberID="viewController">
                     <tabViewItems>
-                        <tabViewItem label="Info" image="NSInfo" id="fCK-nG-5Tl"/>
                         <tabViewItem label="General" identifier="" image="NSPreferencesGeneral" id="Zw5-Ce-8bO"/>
                         <tabViewItem label="DeveloperDiskImages" image="NSFolder" id="7nj-4I-h6E" userLabel="DeveloperDiskImages"/>
                         <tabViewItem label="Network" identifier="" image="NSNetwork" id="gbr-Wo-Ace"/>
@@ -2463,7 +2462,6 @@
                         </connections>
                     </tabView>
                     <connections>
-                        <segue destination="uVV-Vv-12T" kind="relationship" relationship="tabItems" id="odq-jy-Lbr"/>
                         <segue destination="eae-4P-ykM" kind="relationship" relationship="tabItems" id="A2N-3S-Vxn"/>
                         <segue destination="ToF-vt-NtF" kind="relationship" relationship="tabItems" id="pDF-Dg-gVG"/>
                         <segue destination="7gW-SW-Mts" kind="relationship" relationship="tabItems" id="wHO-xv-mde"/>
@@ -2931,22 +2929,7 @@
             </objects>
             <point key="canvasLocation" x="-136" y="1548"/>
         </scene>
-        <!--Info View Controller-->
-        <scene sceneID="fza-CR-btx">
-            <objects>
-                <viewController id="uVV-Vv-12T" customClass="InfoViewController" customModule="LocationSimulator" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" id="Wj1-Wf-B6v">
-                        <rect key="frame" x="0.0" y="0.0" width="664" height="16"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </view>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="localeKey" value="INFO_TITLE_SETTING"/>
-                    </userDefinedRuntimeAttributes>
-                </viewController>
-                <customObject id="mX0-Ez-e8l" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-1604" y="1661"/>
-        </scene>
+
         <!--Network View Controller-->
         <scene sceneID="Irb-r9-9bb">
             <objects>

--- a/LocationSimulator/Supporting Files/LocationSimulator.entitlements
+++ b/LocationSimulator/Supporting Files/LocationSimulator.entitlements
@@ -2,29 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>com.apple.CoreSimulator</string>
 	</array>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
-	<key>com.apple.security.device.usb</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
-	<key>com.apple.security.personal-information.location</key>
 	<true/>
 	<key>com.apple.security.temporary-exception.sbpl</key>
 	<array>
-		<string>(allow network-outbound (literal &quot;/private/var/run/usbmuxd&quot;))</string>
+		<string>(allow network-outbound (literal "/private/var/run/usbmuxd"))</string>
 	</array>
 </dict>
 </plist>

--- a/LocationSimulator/ViewController/MapViewController/MapViewController.swift
+++ b/LocationSimulator/ViewController/MapViewController/MapViewController.swift
@@ -358,14 +358,28 @@ import LocationSpoofer
         self.deviceIsConnectd = false
 
         switch error {
-        case DeviceError.devDiskImageNotFound(_):
-            // Try to download the developer disk image and retry the upload.
-            let os = device.productName!
-            let version = device.majorMinorVersion!
-            if self.downloadDeveloperDiskImage(os: os, iOSVersion: version) {
-                self.connectDevice()
+        case DeviceError.devDiskImageNotFound(let msg):
+            // Check if this is an iOS 17+ device that needs pymobiledevice3
+            if device.requiresPMD3 {
+                window.showError(
+                    "iOS 17+ Device Setup",
+                    message: msg.isEmpty ?
+                        "This device requires pymobiledevice3 for location simulation.\n\n" +
+                        "1. Install: python3 -m pip install pymobiledevice3\n" +
+                        "2. Then restart LocationSimulator.\n\n" +
+                        "When connecting, you'll be prompted for your admin password to start the tunnel service."
+                        : msg,
+                    localize: false
+                )
             } else {
-                window.showError("DEVDISK_DOWNLOAD_FAILED_ERROR", message: "DEVDISK_DOWNLOAD_FAILED_ERROR_MSG")
+                // Try to download the developer disk image and retry the upload.
+                let os = device.productName!
+                let version = device.majorMinorVersion!
+                if self.downloadDeveloperDiskImage(os: os, iOSVersion: version) {
+                    self.connectDevice()
+                } else {
+                    window.showError("DEVDISK_DOWNLOAD_FAILED_ERROR", message: "DEVDISK_DOWNLOAD_FAILED_ERROR_MSG")
+                }
             }
         case DeviceError.devMode:
             device.enabledDeveloperModeToggleInSettings()

--- a/LocationSimulator/ViewController/SidebarViewController/SidebarViewController.swift
+++ b/LocationSimulator/ViewController/SidebarViewController/SidebarViewController.swift
@@ -175,7 +175,13 @@ class SidebarViewController: NSViewController {
                     // A device was connected => create and show the corresponding MapViewController.
                     viewController = self.storyboard?.instantiateController(withIdentifier: "MapViewController")
                     if let mapViewController = viewController as? MapViewController {
-                        mapViewController.device = device
+                        // Wrap iOS 17+ devices in PMD3DeviceWrapper for pymobiledevice3 support
+                        if let iosDevice = device as? IOSDevice,
+                           PMD3Helper.deviceRequiresPMD3(iosDevice.majorVersion) {
+                            mapViewController.device = PMD3DeviceWrapper(wrapping: iosDevice)
+                        } else {
+                            mapViewController.device = device
+                        }
                         // Set the currently selected move type.
                         let windowController = self.view.window?.windowController as? WindowController
                         mapViewController.moveType = windowController?.moveType

--- a/README.md
+++ b/README.md
@@ -96,18 +96,30 @@ When you select an iOS 17+ device in LocationSimulator:
 
 ## Install
 
-Download the latest [release](https://github.com/Schlaubischlump/LocationSimulator/releases) build from github to get the latest changes or
+### Option 1: Download DMG (Recommended)
 
-1. Install [homebrew](https://brew.sh) by entering the following command in your terminal: 
+Download the latest DMG from [**Releases**](https://github.com/bhargavchintam/LocationSimulator/releases/latest), open it, and drag **LocationSimulator** to your **Applications** folder.
+
+> **Note**: Since this build is ad-hoc signed, macOS may show a warning. Right-click the app → **Open** to bypass Gatekeeper on first launch.
+
+### Option 2: Homebrew
+
+1. Install [Homebrew](https://brew.sh) if you don't have it:
 
 	```shell
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 	```
-2. Install LocationSimulator with [homebrew](https://brew.sh) using:
+
+2. Tap this repo and install:
 
 	```shell
-	brew install locationsimulator
+	brew tap bhargavchintam/LocationSimulator https://github.com/bhargavchintam/LocationSimulator
+	brew install --cask bhargavchintam/LocationSimulator/locationsimulator
 	```
+
+### Option 3: Build from source
+
+See the [Build](#build) section below.
 
 ## Build
 


### PR DESCRIPTION
## Summary

This PR adds **iOS 17+ location simulation support** using [pymobiledevice3](https://github.com/doronz88/pymobiledevice3), since Apple removed the legacy `com.apple.dt.simulatelocation` lockdown service starting with iOS 17.

## Changes

### New Files
- **`PMD3Helper.swift`** — Wraps the pymobiledevice3 CLI for iOS 17+ devices:
  - Auto-discovers the `pymobiledevice3` binary
  - Manages `tunneld` lifecycle (starts with admin privileges via `osascript`)
  - Uses DVT instruments protocol (`developer dvt simulate-location`) for persistent location simulation
  - Handles negative coordinates with `--` separator
  
- **`PMD3DeviceWrapper.swift`** — `Device` protocol wrapper that routes `simulateLocation`/`disableSimulation` through pymobiledevice3 for iOS 17+, while delegating everything else to the original `IOSDevice`

### Modified Files
- **`Device+Extension.swift`** — Starts tunneld during the pairing step for iOS 17+ devices
- **`SidebarViewController.swift`** — Wraps iOS 17+ devices in `PMD3DeviceWrapper` when selected
- **`MapViewController.swift`** — Shows iOS 17+ specific error messages with installation instructions
- **`AppDelegate.swift`** — Removed auto-opening Info view on version update
- **`Main.storyboard`** — Removed Info preference tab
- **`project.pbxproj`** — Added new source files; disabled `ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS` to fix Xcode 26 build conflicts with existing `NSColor` extensions

### Documentation
- **`README.md`** — Added iOS 17+ setup section with prerequisites, instructions, and troubleshooting table

## How It Works

1. When an iOS 17+ device is selected, it's wrapped in `PMD3DeviceWrapper`
2. During pairing, `tunneld` is started as a background daemon (requires one-time admin password)
3. Location simulation uses `pymobiledevice3 developer dvt simulate-location set --tunnel <UDID> -- <lat> <lon>`
4. The DVT process runs persistently to maintain the simulated location
5. On reset/quit, the process is terminated and real GPS resumes

## Testing
- Tested with iPhone 15 Pro running iOS 26.3
- Verified tunneld starts and tunnel is accessible at `http://127.0.0.1:49151`
- Confirmed location changes on device using Apple Maps

## Prerequisites for Users
- Python 3.8+
- `pymobiledevice3` (`pip install pymobiledevice3`)
- Developer Mode enabled on the iOS device
